### PR TITLE
Add ExtractDateTime fn

### DIFF
--- a/timebot/timebot.go
+++ b/timebot/timebot.go
@@ -5,6 +5,7 @@ package timebot
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	s "strings"
 	"time"
 )
@@ -90,4 +91,19 @@ func ParseAndFlipTz(text string) (string, error) {
 	}
 
 	return "", fmt.Errorf("%v does not contain PST/PDT/KST", text)
+}
+
+// Regex for 2006-01-02 15:04 MST
+// nolint:gochecknoglobals
+var datetimeRegex = regexp.MustCompile(`\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\s[A-z]{3}`)
+
+// ExtractDateTime extracts DateTime from 'text'
+func ExtractDateTime(text string) (string, error) {
+	find := datetimeRegex.FindString(text)
+
+	if find != "" {
+		return find, nil
+	}
+
+	return "", errors.New("text does not contain valid date time format (e.g., 2006-01-02 15:04 MST)")
 }

--- a/timebot/timebot_test.go
+++ b/timebot/timebot_test.go
@@ -166,3 +166,77 @@ func TestParseAndFlipTz(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractDateTime(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		err      bool
+	}{
+		{
+			input:    "이번 미팅은 2019-01-04 21:51 KST 에 하겠습니다",
+			expected: "2019-01-04 21:51 KST",
+		},
+		{
+			// empty string should fail
+			input: "",
+			err:   true,
+		},
+		{
+			// if it doesn't contain datetime, err
+			input: "이번 미팅은 에 하겠습니다",
+			err:   true,
+		},
+		{
+			input:    "ㄴㅇ이ㄱ자ㅂㄴㅇㅣㅇㅂ자ㅇㄴㅇㅣㅂ자 2019-01-04 21:52 PST",
+			expected: "2019-01-04 21:52 PST",
+		},
+	}
+
+	for _, testCase := range testCases {
+		output, err := ExtractDateTime(testCase.input)
+
+		switch testCase.err {
+
+		case true:
+
+			if err == nil {
+
+				// "should fail" case but succeeded
+				t.Fatalf(`
+test should fail but did not return error
+
+Input:
+	%v
+`, testCase.input)
+			}
+
+		case false:
+
+			if err != nil {
+				// "success" case but failed
+				t.Fatalf(`
+test should not fail but failed
+
+Input:
+	%v
+Error:
+	%v
+`, testCase.input, err)
+
+			}
+
+			if output != testCase.expected {
+				// output was wrong
+				t.Fatalf(`
+Expected:
+	%v
+Received:
+	%v
+`, testCase.expected, output)
+
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
## Summary

1. Add `ExtractDateTime` function to respond to slack messages in real-time instead of using **/time** command

*Example*

```golang
out, _ := ExtractDateTime("이번 미팅은 2019-01-04 21:51 KST 에 하겠습니다")
fmt.Println(out) // "2019-01-04 21:51 KST"
```

```golang
_, err := ExtractDateTime("이번 미팅은 에 하겠습니다")
fmt.Println(err) // "text does not contain valid date time format (e.g., 2006-01-02 15:04 MST)"
```

## Related 

#18 