### PR TITLE
Pass slack signature verification test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /.vscode/
 /play/*
 secret.sh
+/play_ground/*

--- a/api/slack/verification_test.go
+++ b/api/slack/verification_test.go
@@ -9,22 +9,18 @@ import (
 
 //nolint:lll
 func TestVerify(t *testing.T) {
-	t.Skip("DELETE THIS")
 	slackSigningToken := []byte("8f742231b10e8888abcd99yyyzzz85a5")
-	body := []byte("token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
-	var timestamp int64 = 1531420618
+	timestamp := "1531420618"
+	body := "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+	receivedMAC := "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"
 
-	expectedHex := []byte("v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503")
-
-	if ok := Verify(slackSigningToken, body, timestamp, expectedHex); !ok {
+	if ok := Verify(slackSigningToken, timestamp, body, receivedMAC); !ok {
 		t.Fatal("Failed to verify")
 	}
 }
 
 //nolint:lll
 func TestVerifyRequest(t *testing.T) {
-	t.Skip("DELETE THIS")
-
 	bodyRaw := "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
 	body := bytes.NewBufferString(bodyRaw)
 	req, _ := http.NewRequest("POST", "/api/doesn'tmatter", body)


### PR DESCRIPTION
1. VerifyRequest()
	- extract string from request header and body
	- do not consume body - use GetBody()
	- call Verify
2. Verify()
	- concatenate to message
	- call CheckMAC
3. CheckMAC()
	- calculate MAC from message and key
	- compare calcualtedMAC and receivedMAC