### PR TITLE
verfiy  slack message from the internet / use hmac.Equal() for verifying

### DIFF
--- a/api/slack/slack.go
+++ b/api/slack/slack.go
@@ -3,7 +3,9 @@ package slack
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
 
 	"github.com/dl4ab/timebot/timebot"
 )
@@ -16,6 +18,17 @@ import (
 // /time 2018-12-31 21:40 PST
 // => 2019-01-01 14:40 KST
 func CommandHandler(w http.ResponseWriter, r *http.Request) {
+
+	slackSigningToken := os.Getenv("SLACK_SIGNING_SECRET")
+	if slackSigningToken == "" {
+		log.Printf("$SLACK_SIGNING_SECRET must be set")
+	} else if ok := VerifyRequest(r, []byte(slackSigningToken)); !ok {
+		log.Printf("Slack signature not verifed")
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	log.Printf("Slack signature verifed")
+
 	err := r.ParseForm()
 
 	if err != nil {


### PR DESCRIPTION
1. consume 을 피하기 위해 사용한 request.GetBody() 는 client 단에서 쓸 수 있는 것이라 합니다. 
이에 다른 solution을 찾았습니다. 
- https://goo.gl/MYjSI2

2. 저번에 언급되었던 hmac.Equal() 를 사용하였습니다. 

*sorry for two job in one commit

