### PR TITLE
Fix CI build errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,1 @@
 linters:
-    enable-all: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ go:
 # build and immediately stop. It's sorta like having set -e enabled in bash.
 # Make sure golangci-lint is vendored.
 before_script:
-    # binary will be $GOPATH/bin/golangci-lint
-    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.16.0 && golangci-lint --version
-    - go get github.com/mattn/goveralls
+  # binary will be $GOPATH/bin/golangci-lint
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0 && golangci-lint --version
+  - go get github.com/mattn/goveralls
 
 # script always runs to completion (set +e). If we have linter issues AND a
 # failing test, we want to see both. Configure golangci-lint with a
 # .golangci.yml file at the top level of your repo.
 script:
-  - golangci-lint run       # run a bunch of code checkers/linters in parallel
+  - golangci-lint run # run a bunch of code checkers/linters in parallel
   - goveralls -service=travis-ci

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.1
 )
+
+go 1.13


### PR DESCRIPTION
- Use default linters instead of enabling all
- Update golangci-lint to the latest version